### PR TITLE
Support Python 3 with "six" instead of running `2to3`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,9 @@ setup(
     url = 'http://github.com/agrover/targetcli-fb',
     packages = ['targetcli'],
     scripts = ['scripts/targetcli'],
-    use_2to3 = True,
+    classifiers = [
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+    ],
     )

--- a/targetcli/__init__.py
+++ b/targetcli/__init__.py
@@ -15,5 +15,5 @@ License for the specific language governing permissions and limitations
 under the License.
 '''
 
-from ui_root import UIRoot
-from version import __version__
+from .ui_root import UIRoot
+from .version import __version__

--- a/targetcli/ui_backstore.py
+++ b/targetcli/ui_backstore.py
@@ -17,17 +17,19 @@ License for the specific language governing permissions and limitations
 under the License.
 '''
 
-from ui_node import UINode, UIRTSLibNode
-from rtslib_fb import RTSRoot
-from rtslib_fb import FileIOStorageObject, BlockStorageObject
-from rtslib_fb import PSCSIStorageObject, RDMCPStorageObject, UserBackedStorageObject
-from rtslib_fb import RTSLibError
-from rtslib_fb.utils import get_block_type
-from configshell_fb import ExecutionError
 import glob
 import os
-import stat
 import re
+import stat
+
+from configshell_fb import ExecutionError
+from rtslib_fb import BlockStorageObject, FileIOStorageObject
+from rtslib_fb import PSCSIStorageObject, RDMCPStorageObject, UserBackedStorageObject
+from rtslib_fb import RTSLibError
+from rtslib_fb import RTSRoot
+from rtslib_fb.utils import get_block_type
+
+from .ui_node import UINode, UIRTSLibNode
 
 def human_to_bytes(hsize, kilo=1024):
     '''

--- a/targetcli/ui_node.py
+++ b/targetcli/ui_node.py
@@ -17,6 +17,8 @@ License for the specific language governing permissions and limitations
 under the License.
 '''
 
+import six
+
 from configshell_fb import ConfigNode, ExecutionError
 from rtslib_fb import RTSLibError, RTSRoot
 
@@ -204,6 +206,6 @@ class UIRTSLibNode(UINode):
         for item in ('attributes', 'parameters'):
             if item in info:
                 del info[item]
-        for name, value in sorted(info.iteritems()):
+        for name, value in sorted(six.iteritems(info)):
             if not isinstance (value, (dict, list)):
                 self.shell.log.info("%s: %s" % (name, value))

--- a/targetcli/ui_root.py
+++ b/targetcli/ui_root.py
@@ -17,19 +17,20 @@ License for the specific language governing permissions and limitations
 under the License.
 '''
 
+from datetime import datetime
+from glob import glob
+import json
+import os
+import shutil
+import stat
+
+from configshell_fb import ExecutionError
 from rtslib_fb import RTSRoot
 from rtslib_fb.utils import ignored
-from configshell_fb import ExecutionError
-from ui_node import UINode
-from socket import gethostname
-from ui_target import UIFabricModule
-from ui_backstore import UIBackstores, complete_path
-import json
-import shutil
-import os
-import stat
-from glob import glob
-from datetime import datetime
+
+from .ui_backstore import complete_path, UIBackstores
+from .ui_node import UINode
+from .ui_target import UIFabricModule
 
 default_save_file = "/etc/target/saveconfig.json"
 kept_backups = 10

--- a/targetcli/ui_target.py
+++ b/targetcli/ui_target.py
@@ -17,18 +17,21 @@ License for the specific language governing permissions and limitations
 under the License.
 '''
 
-from ui_node import UINode, UIRTSLibNode
-from ui_backstore import complete_path
-from rtslib_fb import RTSLibError, RTSLibBrokenLink, utils
-from rtslib_fb import NodeACL, NetworkPortal, MappedLUN
-from rtslib_fb import Target, TPG, LUN, StorageObjectFactory
-from configshell_fb import ExecutionError
-import os
-import stat
 try:
     import ethtool
 except ImportError:
     ethtool = None
+import os
+import six
+import stat
+
+from configshell_fb import ExecutionError
+from rtslib_fb import RTSLibBrokenLink, RTSLibError, utils
+from rtslib_fb import MappedLUN, NetworkPortal, NodeACL
+from rtslib_fb import LUN, Target, TPG, StorageObjectFactory
+
+from .ui_backstore import complete_path
+from .ui_node import UINode, UIRTSLibNode
 
 auth_params = ('userid', 'password', 'mutual_userid', 'mutual_password')
 discovery_params = auth_params + ("enable",)
@@ -1023,7 +1026,7 @@ class UINodeACL(UIRTSLibNode):
         for item in ('attributes', 'parameters', "node_wwn"):
             if item in info:
                 del info[item]
-        for name, value in sorted(info.iteritems()):
+        for name, value in sorted(six.iteritems(info)):
             if not isinstance (value, (dict, list)):
                 self.shell.log.info("%s: %s" % (name, value))
         self.shell.log.info("wwns:")
@@ -1136,7 +1139,7 @@ class UILUNs(UINode):
                 existing_mluns = [mlun.mapped_lun for mlun in acl.mapped_luns]
                 if mapped_lun in existing_mluns:
                     mapped_lun = None
-                    for possible_mlun in xrange(LUN.MAX_LUN):
+                    for possible_mlun in six.moves.range(LUN.MAX_LUN):
                         if possible_mlun not in existing_mluns:
                             mapped_lun = possible_mlun
                             break


### PR DESCRIPTION
 * Replace dict.iteritems() with six.iteritems(dict)
 * Use six.moves.range() to get xrange() on Python 2 and range() on
   Python 3
 * Add classifiers to setup.py
 * Sort imports

Signed-off-by: Christophe Vu-Brugier <cvubrugier@fastmail.fm>