### PR TITLE
Fix package name for rpm spec file

### DIFF
--- a/rpm/targetcli.spec.tmpl
+++ b/rpm/targetcli.spec.tmpl
@@ -1,4 +1,4 @@
-%define oname targetcli
+%define oname targetcli-fb
 
 Name:           targetcli
 License:        Apache License 2.0


### PR DESCRIPTION
The package name used by the Makefile to generate the tarball is `targetcli-fb` while the rpm spec defines the package name to `targetcli`, which results the following error when trying to build the rpm package:
```
Building rpm packages...
error: File /path/to/targetcli-fb/dist/targetcli-2.1.fb42.1.g8b927cc.tar.gz: No such file or directory
make: *** [build/rpm-stamp] Error 1
```

Signed-off-by: runsisi <runsisi@hust.edu.cn>